### PR TITLE
plan: inventory + AGENTS.md + refactor roadmap

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,7 @@
+# Backend configuration
+DATABASE_URL=postgresql://adobe_stock_user:adobe_stock_password@localhost:5432/adobe_stock_processor
+REDIS_URL=redis://localhost:6379
+
+# Frontend configuration
+NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXT_PUBLIC_WS_URL=ws://localhost:8000

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS
+
+This repository is under an incremental refactor. Follow these guardrails for any change.
+
+## Development Setup
+- Python 3.11+
+- Node 18+
+- Install backend dependencies: `pip install -r requirements.txt`
+- Install frontend dependencies: `npm install` (run from `frontend`)
+- Copy `.env.sample` to `.env` and adjust values as needed
+
+## Commands
+- Run tests before committing: `pytest`
+- Start backend: `uvicorn backend.main:app --reload`
+- Start frontend: `npm run dev`
+- Start services with Docker: `docker-compose up -d`
+
+## Database
+- **PostgreSQL only.** The app should run against a local Docker PostgreSQL instance.
+- Remove or migrate any SQLite or other database references.
+
+## Contribution Guidelines
+- Prefer refactoring over rewriting.
+- Keep pull requests small (≤300 changed lines).
+- Ensure tests pass and relevant docs are updated.
+- Stay within the canonical repo layout:
+  - `/backend` – FastAPI application
+  - `/frontend` – Next.js web client
+  - `/infra` – Docker and infrastructure configs

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,40 @@
+# Refactor Roadmap
+
+## Inventory of Suspected Unused / Duplicate Files
+- `demos/` – standalone demo scripts
+- `scripts/` – multiple utility/report scripts (`create_csv_report.py`, `create_html_dashboard.py`, etc.)
+- Root docs left from earlier tasks: `FINAL_INTEGRATION_SUMMARY.md`, `TASK_31_IMPLEMENTATION_SUMMARY.md`, `TASK_32_IMPLEMENTATION_SUMMARY.md`, `PROJECT_STRUCTURE.md`
+- Windows helper scripts: `setup_postgres.bat`, `docker_commands.bat`
+- Environment artifacts: `.kiro/`, `.venv/`, `test_results/`
+- SQLite helpers: `backend/use_sqlite.py`, `backend/test_with_sqlite.py`, `backend/core/database.py`
+
+## Database References
+- PostgreSQL configs: `docker-compose.yml`, `backend/database/connection.py`, `backend/database/alembic/*`
+- SQLite usage: `backend/use_sqlite.py`, `backend/test_with_sqlite.py`, `scripts/*report*.py`, `backend/core/database.py`, various tests under `backend/tests`
+- Goal: consolidate on PostgreSQL via Docker; remove SQLite and other DB references.
+
+## Proposed Canonical Layout
+```
+/ backend  - FastAPI application
+/ frontend - Next.js interface
+/ infra    - docker-compose, deployment scripts, environment files
+```
+
+## Step-by-Step PR Plan
+1. **Remove SQLite helpers and tests**
+   - Delete `backend/use_sqlite.py`, `backend/test_with_sqlite.py`, related tests.
+   - Update `backend/database/connection.py` to drop SQLite fallback.
+2. **Prune demo and report scripts**
+   - Delete `demos/` contents and unused scripts in `scripts/`.
+3. **Cleanup legacy docs and artifacts**
+   - Remove task summary files, `.kiro/`, `test_results/`, and Windows `.bat` helpers.
+4. **Introduce `/infra` directory**
+   - Move `docker-compose.yml`, deployment scripts, and environment samples into `infra/`.
+5. **Consolidate database configuration**
+   - Create single DB config module; update tests and README to point to Postgres.
+6. **Rationalize test suite**
+   - Remove redundant tests and ensure remaining tests rely on Postgres fixtures.
+7. **Document standard development workflow**
+   - Update README and docs with canonical commands and layout.
+
+Each PR should change ≤300 lines and include test runs.


### PR DESCRIPTION
## Summary
- document repo guardrails and workflows in new `AGENTS.md`
- provide environment template and plan for Postgres-only setup
- outline unused assets and future refactor roadmap in `PLAN.md`

## Testing
- `pytest -q` *(fails: `/workspace/image_processor/pytest.ini:46: unexpected line: '-n auto'`)*
- `pytest -q -c /dev/null` *(fails: missing modules such as `sqlalchemy`, `fastapi`, `psutil`, `requests`, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689a5a415edc83248c59175a10ea260d