### PR TITLE
refactor: unify database to Postgres-only

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -53,10 +53,10 @@ pip install fastapi uvicorn sqlalchemy asyncpg pydantic
 sudo apt-get install postgresql postgresql-contrib
 
 # Create database
-sudo -u postgres createdb adobe_stock_processor
+sudo -u postgres createdb stockdb
 
 # Set environment variable
-export DATABASE_URL="postgresql+asyncpg://postgres:password@localhost:5432/adobe_stock_processor"
+export DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:5432/stockdb"
 ```
 
 ### 3. Start the Server
@@ -119,7 +119,7 @@ Configuration is managed through JSON files in `backend/config/`:
     "min_resolution": [800, 600]
   },
   "database": {
-    "url": "postgresql+asyncpg://postgres:password@localhost:5432/adobe_stock_processor"
+    "url": "postgresql+asyncpg://postgres:postgres@localhost:5432/stockdb"
   }
 }
 ```

--- a/backend/database/connection.py
+++ b/backend/database/connection.py
@@ -13,10 +13,11 @@ logger = logging.getLogger(__name__)
 
 # Database configuration
 load_dotenv()
-DATABASE_URL = os.getenv(
-    "DATABASE_URL",
-    "postgresql+asyncpg://postgres:postgres@localhost:5432/stockdb"
-)
+DATABASE_URL = os.getenv("DATABASE_URL")
+if not DATABASE_URL:
+    raise RuntimeError("DATABASE_URL is not set.")
+if DATABASE_URL.startswith("postgresql://"):
+    DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
 
 # SQLAlchemy setup
 Base = declarative_base()
@@ -44,16 +45,12 @@ class DatabaseManager:
         
         try:
             # Create async engine with enhanced connection pooling
-            connect_args = {}
-            
-            # PostgreSQL-specific settings
-            if "postgresql" in self.database_url:
-                connect_args = {
-                    "server_settings": {
-                        "application_name": "adobe_stock_processor_api",
-                        "jit": "off"  # Disable JIT for better connection performance
-                    }
+            connect_args = {
+                "server_settings": {
+                    "application_name": "adobe_stock_processor_api",
+                    "jit": "off"  # Disable JIT for better connection performance
                 }
+            }
             
             self.engine = create_async_engine(
                 self.database_url,

--- a/backend/main.py
+++ b/backend/main.py
@@ -34,7 +34,6 @@ try:
     from backend.analyzers.compliance_checker import ComplianceChecker
     from backend.core.decision_engine import DecisionEngine
     from backend.utils.report_generator import ReportGenerator
-    from backend.utils.path_utils import get_database_path
 except ImportError:
     # Standalone mode - use relative imports
     from config.config_loader import load_config, AppConfig
@@ -49,7 +48,6 @@ except ImportError:
     from analyzers.compliance_checker import ComplianceChecker
     from core.decision_engine import DecisionEngine
     from utils.report_generator import ReportGenerator
-    from utils.path_utils import get_database_path
 
 
 class ImageProcessor:
@@ -77,10 +75,6 @@ class ImageProcessor:
             self._setup_signal_handlers()
             
             # Initialize core components
-            db_path = getattr(self.config, 'database', {}).get('path', None)
-            if isinstance(db_path, dict):
-                db_path = None
-            
             self.progress_tracker = PostgresProgressTracker(
                 checkpoint_interval=self.config.processing.checkpoint_interval
             )

--- a/backend/scripts/run_migrations.py
+++ b/backend/scripts/run_migrations.py
@@ -17,6 +17,18 @@ from database.init_db import DatabaseInitializer
 
 logger = logging.getLogger(__name__)
 
+
+def _get_database_url() -> str:
+    """Load and normalize DATABASE_URL from environment."""
+    database_url = os.getenv("DATABASE_URL")
+    if not database_url:
+        raise RuntimeError("DATABASE_URL is not set.")
+    if database_url.startswith("postgresql://"):
+        database_url = database_url.replace(
+            "postgresql://", "postgresql+asyncpg://", 1
+        )
+    return database_url
+
 async def run_migrations():
     """Run Alembic database migrations."""
     try:
@@ -33,10 +45,7 @@ async def run_migrations():
         alembic_cfg.set_main_option("script_location", str(repo_root / "infra" / "migrations"))
         
         # Set database URL from environment
-        database_url = os.getenv(
-            "DATABASE_URL",
-            "postgresql+asyncpg://postgres:password@localhost:5432/adobe_stock_processor"
-        )
+        database_url = _get_database_url()
         alembic_cfg.set_main_option("sqlalchemy.url", database_url)
         
         logger.info("Running database migrations...")
@@ -78,10 +87,7 @@ async def create_migration(message: str):
         alembic_cfg.set_main_option("script_location", str(repo_root / "infra" / "migrations"))
         
         # Set database URL from environment
-        database_url = os.getenv(
-            "DATABASE_URL",
-            "postgresql+asyncpg://postgres:password@localhost:5432/adobe_stock_processor"
-        )
+        database_url = _get_database_url()
         alembic_cfg.set_main_option("sqlalchemy.url", database_url)
         
         logger.info(f"Creating migration: {message}")
@@ -111,10 +117,7 @@ async def check_migration_status():
         alembic_cfg.set_main_option("script_location", str(repo_root / "infra" / "migrations"))
         
         # Set database URL from environment
-        database_url = os.getenv(
-            "DATABASE_URL",
-            "postgresql+asyncpg://postgres:password@localhost:5432/adobe_stock_processor"
-        )
+        database_url = _get_database_url()
         alembic_cfg.set_main_option("sqlalchemy.url", database_url)
         
         logger.info("Checking migration status...")

--- a/backend/utils/__init__.py
+++ b/backend/utils/__init__.py
@@ -2,7 +2,6 @@
 from .path_utils import (
     get_project_root,
     get_backend_root,
-    get_database_path,
     get_reports_dir,
     get_logs_dir,
     get_data_dir,

--- a/backend/utils/path_utils.py
+++ b/backend/utils/path_utils.py
@@ -31,19 +31,6 @@ def get_backend_root() -> Path:
     return backend_root
 
 
-def get_database_path(db_name: str = "adobe_stock_processor.db") -> str:
-    """Get the database path relative to project root.
-    
-    Args:
-        db_name: Name of the database file.
-        
-    Returns:
-        str: Absolute path to the database file.
-    """
-    project_root = get_project_root()
-    return str(project_root / db_name)
-
-
 def get_reports_dir() -> str:
     """Get the reports directory path relative to project root.
     

--- a/infra/.env.sample
+++ b/infra/.env.sample
@@ -1,7 +1,4 @@
-# Backend configuration
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/stockdb
 REDIS_URL=redis://localhost:6379
-
-# Frontend configuration
 NEXT_PUBLIC_API_URL=http://localhost:8000
 NEXT_PUBLIC_WS_URL=ws://localhost:8000

--- a/infra/alembic.ini
+++ b/infra/alembic.ini
@@ -59,7 +59,7 @@ version_path_separator = os
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = postgresql+asyncpg://postgres:password@localhost:5432/adobe_stock_processor
+sqlalchemy.url = postgresql+asyncpg://postgres:postgres@localhost:5432/stockdb
 
 [post_write_hooks]
 # post_write_hooks defines scripts or Python functions that are run

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -3,17 +3,16 @@ version: '3.8'
 services:
   # PostgreSQL Database
   postgres:
-    image: postgres:15
+    image: postgres:16
     container_name: adobe_stock_postgres
     environment:
-      POSTGRES_DB: adobe_stock_processor
-      POSTGRES_USER: adobe_stock_user
-      POSTGRES_PASSWORD: adobe_stock_password
+      POSTGRES_DB: stockdb
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
     ports:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ../backend/database/init.sql:/docker-entrypoint-initdb.d/init.sql
     networks:
       - adobe_stock_network
 
@@ -37,7 +36,7 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - DATABASE_URL=postgresql://adobe_stock_user:adobe_stock_password@postgres:5432/adobe_stock_processor
+      - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/stockdb
       - REDIS_URL=redis://redis:6379
     volumes:
       - ../data:/app/data

--- a/infra/migrations/env.py
+++ b/infra/migrations/env.py
@@ -35,12 +35,16 @@ target_metadata = Base.metadata
 # my_important_option = config.get_main_option("my_important_option")
 # ... etc.
 
-def get_database_url():
-    """Get database URL from environment or config."""
-    return os.getenv(
-        "DATABASE_URL",
-        "postgresql+asyncpg://postgres:password@localhost:5432/adobe_stock_processor"
-    )
+def get_database_url() -> str:
+    """Get normalized database URL from environment."""
+    database_url = os.getenv("DATABASE_URL")
+    if not database_url:
+        raise RuntimeError("DATABASE_URL is not set.")
+    if database_url.startswith("postgresql://"):
+        database_url = database_url.replace(
+            "postgresql://", "postgresql+asyncpg://", 1
+        )
+    return database_url
 
 def run_migrations_offline() -> None:
     """Run migrations in 'offline' mode.


### PR DESCRIPTION
## Summary
- require `DATABASE_URL` from environment and normalize to asyncpg
- drop legacy SQLite helpers and unused database path utilities
- update Docker and env samples for Postgres 16

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ab8e528b08324a606aff10795257d