### PR TITLE
refactor: normalize repo structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ From `infra/.env.sample`:
 
 ## Commands
 - Run tests before committing: `pytest`
-- Start backend: `python backend/main.py server --reload`
+- Start backend: `uvicorn backend.api.main:socket_app --reload`
 - Start frontend: `(cd frontend && npm run dev)`
 - Start services with Docker: `(cd infra && docker-compose up -d)`
 

--- a/README.md
+++ b/README.md
@@ -7,28 +7,10 @@ A modern desktop application for analyzing and filtering large collections of im
 This application follows a clean, modern architecture:
 
 ```
-adobe-stock-processor/
-├── backend/                # Python FastAPI backend
-│   ├── api/               # REST API endpoints
-│   ├── core/              # Core processing logic
-│   ├── analyzers/         # AI/ML image analysis modules
-│   ├── utils/             # Backend utilities
-│   ├── database/          # Database models
-│   └── main.py           # Backend entry point
-├── frontend/              # Next.js frontend (to be implemented)
-├── infra/                 # Docker, environment, migrations
-├── data/                  # Unified data directory
-│   ├── input/            # Test input images
-│   ├── output/           # Processing results
-│   └── temp/             # Temporary files
-├── tools/                 # Development and utility tools
-├── scripts/               # Processing and report scripts
-├── demos/                 # Demo applications
-├── tests/                 # Test suite
-├── docs/                  # Documentation
-├── reports/               # Generated reports
-├── logs/                  # Application logs
-└── README.md             # This file
+image_processor/
+├── backend/   # FastAPI backend and workers
+├── frontend/  # Next.js web client
+└── infra/     # Docker compose, migrations, env samples
 ```
 
 ## Features
@@ -90,7 +72,7 @@ adobe-stock-processor/
 5. **Or run locally**
    ```bash
    # Start backend
-   python backend/main.py server
+   uvicorn backend.api.main:socket_app --reload
 
    # Access web interface at http://localhost:3000
    ```
@@ -105,7 +87,7 @@ python backend/main.py process input_folder output_folder
 python backend/main.py resume
 
 # Start API server
-python backend/main.py server
+uvicorn backend.api.main:socket_app --reload
 
 # Show all options
 python backend/main.py --help

--- a/backend/README.md
+++ b/backend/README.md
@@ -63,10 +63,10 @@ export DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:5432/stock
 
 ```bash
 # Start FastAPI server
-python backend/main.py server
+uvicorn backend.api.main:socket_app --reload
 
 # Or with custom options
-python backend/main.py server --host 0.0.0.0 --port 8000 --reload
+uvicorn backend.api.main:socket_app --host 0.0.0.0 --port 8000 --reload
 ```
 
 ### 4. Access API Documentation
@@ -166,7 +166,7 @@ python -c "from backend.database.migrations import run_migrations; import asynci
 
 ```bash
 # Start with auto-reload
-python backend/main.py server --reload
+uvicorn backend.api.main:socket_app --reload
 ```
 
 ## Environment Variables
@@ -185,7 +185,7 @@ The backend maintains compatibility with the existing CLI interface:
 python backend/main.py process --input /path/to/images --output /path/to/output
 
 # API server mode (new functionality)
-python backend/main.py server --port 8000
+uvicorn backend.api.main:socket_app --port 8000
 ```
 
 ## Next Steps


### PR DESCRIPTION
## Summary
- document backend launch via `uvicorn backend.api.main:socket_app --reload`
- simplify repository layout to backend/frontend/infra in docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689abaa4fa848324af094591eeeaadb0