### PR TITLE
chore(frontend): deps cleanup and build stabilization

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_BASE=http://localhost:8000

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,8 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    appDir: true,
-  },
   typescript: {
     ignoreBuildErrors: true,
   },


### PR DESCRIPTION
## Summary
- drop deprecated `appDir` flag from Next.js config
- document `NEXT_PUBLIC_API_BASE` in frontend `.env.example`

## Testing
- `npm dedupe`
- `npm update`
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ac80609a48324a5e07ae91e336559