### PR TITLE
feat(ml): runtime probe + unified detector (GPU fallback)

### DIFF
--- a/backend/analyzers/ai_quality_analyzer.py
+++ b/backend/analyzers/ai_quality_analyzer.py
@@ -16,22 +16,22 @@ from typing import Dict, Any, Optional, Tuple, Union, List
 from dataclasses import dataclass
 from pathlib import Path
 
+from backend.ml import runtime
+
+probe = runtime.probe()
+tf = probe.tf
+cv2 = probe.cv2
+TF_AVAILABLE = tf is not None
+CV2_AVAILABLE = cv2 is not None
+
 try:
-    import tensorflow as tf
-    import cv2
     import numpy as np
     from PIL import Image
-    TF_AVAILABLE = True
-    CV2_AVAILABLE = True
     PIL_AVAILABLE = True
 except ImportError as e:
-    logging.warning(f"AI/ML dependencies not available: {e}")
-    tf = None
-    cv2 = None
+    logging.warning(f"Optional dependencies not available: {e}")
     np = None
     Image = None
-    TF_AVAILABLE = False
-    CV2_AVAILABLE = False
     PIL_AVAILABLE = False
 
 from .ai_model_manager import AIModelManager

--- a/backend/analyzers/ai_similarity_finder.py
+++ b/backend/analyzers/ai_similarity_finder.py
@@ -17,39 +17,39 @@ from typing import Dict, Any, Optional, Tuple, Union, List
 from dataclasses import dataclass
 from pathlib import Path
 
+from backend.ml import runtime
+
+probe = runtime.probe()
+tf = probe.tf
+cv2 = probe.cv2
+TF_AVAILABLE = tf is not None
+CV2_AVAILABLE = cv2 is not None
+
 try:
-    import tensorflow as tf
     import torch
     import clip
-    import cv2
     import numpy as np
     from PIL import Image
     import imagehash
     from sklearn.cluster import DBSCAN
     from sklearn.metrics.pairwise import cosine_similarity
     from sklearn.preprocessing import StandardScaler
-    TF_AVAILABLE = True
     TORCH_AVAILABLE = True
     CLIP_AVAILABLE = True
-    CV2_AVAILABLE = True
     PIL_AVAILABLE = True
     SKLEARN_AVAILABLE = True
 except ImportError as e:
     logging.warning(f"AI/ML dependencies not available: {e}")
-    tf = None
     torch = None
     clip = None
-    cv2 = None
     np = None
     Image = None
     imagehash = None
     DBSCAN = None
     cosine_similarity = None
     StandardScaler = None
-    TF_AVAILABLE = False
     TORCH_AVAILABLE = False
     CLIP_AVAILABLE = False
-    CV2_AVAILABLE = False
     PIL_AVAILABLE = False
     SKLEARN_AVAILABLE = False
 

--- a/backend/analyzers/similarity_finder.py
+++ b/backend/analyzers/similarity_finder.py
@@ -9,22 +9,24 @@ This module implements comprehensive image similarity detection including:
 - Group recommendation logic for duplicate detection
 """
 
+from backend.ml import runtime
+
+probe = runtime.probe()
+tf = probe.tf
+cv2 = probe.cv2
+
 try:
-    import cv2
     import numpy as np
     from PIL import Image
     import imagehash
-    import tensorflow as tf
     from sklearn.cluster import DBSCAN
     from sklearn.metrics.pairwise import cosine_similarity
     from sklearn.preprocessing import StandardScaler
 except ImportError:
     # Handle missing dependencies gracefully for testing
-    cv2 = None
     np = None
     Image = None
     imagehash = None
-    tf = None
     DBSCAN = None
     cosine_similarity = None
     StandardScaler = None

--- a/backend/ml/__init__.py
+++ b/backend/ml/__init__.py
@@ -1,0 +1,3 @@
+from .runtime import probe, get_detector
+
+__all__ = ["probe", "get_detector"]

--- a/backend/ml/runtime.py
+++ b/backend/ml/runtime.py
@@ -1,0 +1,83 @@
+import importlib
+import logging
+from types import SimpleNamespace
+
+logger = logging.getLogger(__name__)
+_probe_cache = None
+
+
+def probe():
+    """Detect available ML libraries and hardware.
+
+    Returns a SimpleNamespace with attributes:
+    - tf: TensorFlow module or None
+    - yolo: ultralytics module or None
+    - cv2: OpenCV module or None
+    - torch: PyTorch module or None
+    - cuda: bool indicating if CUDA is available
+    - device: "cuda" or "cpu" depending on CUDA availability
+    """
+    global _probe_cache
+    if _probe_cache is not None:
+        return _probe_cache
+
+    def _try_import(name: str):
+        try:
+            module = importlib.import_module(name)
+            logger.info("%s available", name)
+            return module
+        except Exception as e:
+            logger.info("%s not available: %s", name, e)
+            return None
+
+    tf = _try_import("tensorflow")
+    ultralytics = _try_import("ultralytics")
+    cv2 = _try_import("cv2")
+    torch = _try_import("torch")
+
+    cuda = False
+    if torch is not None:
+        try:
+            cuda = torch.cuda.is_available()
+        except Exception as e:
+            logger.info("torch cuda check failed: %s", e)
+
+    device = "cuda" if cuda else "cpu"
+
+    _probe_cache = SimpleNamespace(
+        tf=tf,
+        yolo=ultralytics,
+        cv2=cv2,
+        torch=torch,
+        cuda=cuda,
+        device=device,
+    )
+
+    logger.info(
+        "ML runtime probe: TF=%s, YOLO=%s, OpenCV=%s, CUDA=%s",
+        bool(tf),
+        bool(ultralytics),
+        bool(cv2),
+        cuda,
+    )
+    return _probe_cache
+
+
+def get_detector(model: str = "yolov8n"):
+    """Load a YOLOv8 detector on the optimal device."""
+    info = probe()
+    if not info.yolo:
+        raise RuntimeError("ultralytics YOLOv8 not installed")
+
+    YOLO = getattr(info.yolo, "YOLO", None)
+    if YOLO is None:
+        raise RuntimeError("YOLO class not found in ultralytics package")
+
+    try:
+        detector = YOLO(model)
+        if info.cuda and hasattr(detector, "to"):
+            detector.to("cuda")
+        return detector
+    except Exception as e:
+        logger.error("Failed to load YOLO model %s: %s", model, e)
+        raise


### PR DESCRIPTION
## Summary
- add ML runtime probing for TensorFlow, ultralytics, OpenCV and CUDA availability
- load YOLOv8 detectors via runtime with automatic GPU fallback
- route AI analyzers through runtime and remove direct ML imports

## Testing
- `pytest` *(fails: SystemExit: 1 in test_ai_compliance)*

------
https://chatgpt.com/codex/tasks/task_e_689ad596a9f88324b7225d248f808c82